### PR TITLE
fix problem with github markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # Contains my Statistical calculator project 
 
 
-#To Do's
+# To Do's
 * make the program able to accept csv's (and maybe other file types in the future)
 * restructure the program to a CLI
 * make a website for the stat calculator


### PR DESCRIPTION
In github markdown, a space is required after that `#` mark to properly indicate a header